### PR TITLE
require scheme to be given parsing localhost URLs

### DIFF
--- a/url.go
+++ b/url.go
@@ -18,7 +18,9 @@ func (u *URL) UnmarshalFlag(value string) error {
 		return err
 	}
 
-	if parsedURL.Scheme == "" {
+	// localhost URLs that do not start with http:// are interpreted
+	// with `localhost` as the Scheme, not the Host
+	if parsedURL.Scheme == "" || parsedURL.Host == "" {
 		return fmt.Errorf("missing scheme in '%s'", value)
 	}
 

--- a/url_test.go
+++ b/url_test.go
@@ -32,4 +32,21 @@ var _ = Describe("URLFlag", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("missing scheme in 'example.com'"))
 	})
+
+	It("returns an error for localhost without scheme", func() {
+		flag := flag.URL{}
+
+		err := flag.UnmarshalFlag("localhost:8080")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("missing scheme in 'localhost:8080'"))
+	})
+
+	It("unmarshalls localhost with scheme correctly", func() {
+		flag := flag.URL{}
+
+		err := flag.UnmarshalFlag("http://localhost:8080")
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(flag.String()).To(Equal("http://localhost:8080"))
+	})
 })


### PR DESCRIPTION
Concourse should now correctly notify users of invalid localhost URLs
when setting the external-url property on atc.

URLs that do not contain a slash after the scheme are parsed as if there
is a schema but no host by url.Parse. This caused localhost URLs without
http schemes to be considered valid even though Concourse requires them
to have the schema.

See: concourse/concourse#1668