### PR TITLE
lager.go: Replaced WriterSink with PrettySink, so that log lines show human readable timestamp.

### DIFF
--- a/lager.go
+++ b/lager.go
@@ -44,7 +44,7 @@ func (f Lager) Logger(component string) (lager.Logger, *lager.ReconfigurableSink
 	if f.writerSink == nil {
 		f.writerSink = os.Stdout
 	}
-	sink := lager.NewReconfigurableSink(lager.NewWriterSink(f.writerSink, lager.DEBUG), minLagerLogLevel)
+	sink := lager.NewReconfigurableSink(lager.NewPrettySink(f.writerSink, lager.DEBUG), minLagerLogLevel)
 
 	logger.RegisterSink(sink)
 


### PR DESCRIPTION
Currently Concourse shows Unix timestamp which is not human readable, look like:

     {"timestamp":"1548643534.139851570","source":"atc","message":"atc.list-destroying-containers.containers-to-destroy","log_level":0,"data":{"count":0,"session":"109","worker":"4c4d8b6dc15d"}}

It's hard to find logs around a certain time point. This commit replace WriterSink with PrettySink, now logs look like:

    {"timestamp":"2019-01-28T03:34:01.843406000Z","level":"error","source":"atc","message":"atc.sky.login.failed-to-parse-claims","data":{"error":"square/go-jose: error in cryptographic primitive","session":"5.3"}}

This more fits human's habit.