### PR TITLE
authorized_keys.go: Provide Reload on authorized_keys

### DIFF
--- a/authorized_keys.go
+++ b/authorized_keys.go
@@ -8,6 +8,7 @@ import (
 )
 
 type AuthorizedKeys struct {
+	File string
 	Keys []ssh.PublicKey
 }
 
@@ -31,7 +32,13 @@ func (f *AuthorizedKeys) UnmarshalFlag(value string) error {
 		authorizedKeysBytes = rest
 	}
 
+	f.File = value
 	f.Keys = authorizedKeys
 
 	return nil
+}
+
+// Reload reloads the value of the Keys
+func (f *AuthorizedKeys) Reload() error {
+	return f.UnmarshalFlag(f.File)
 }


### PR DESCRIPTION
add `AuthorizedKeys.Reload`

This commit add a Reload method on `AuthorizedKeys`, allowing a user to reload keys
from an `AuthorizedKeys` file in a running application by calling the
`Reload` method.

It is up to the user to implement how use it into an application.

To give some examples, a running application can trigger a reload of  `AuthorizedKeys` file following an API call.
You can also catch for example a signal like `SIGUSR1` sent to your running application to trigger a reload of `AuthorizedKeys` file.