### PR TITLE
Add support for the binary_params DSN option

### DIFF
--- a/postgres_config.go
+++ b/postgres_config.go
@@ -23,6 +23,8 @@ type PostgresConfig struct {
 	ClientCert File   `long:"client-cert" description:"Client cert file location."`
 	ClientKey  File   `long:"client-key"  description:"Client key file location."`
 
+	BinaryParameters bool `long:"binary-parameters" description:"Whether or not to use binary parameters for prepared statements." default:"false"`
+
 	ConnectTimeout time.Duration `long:"connect-timeout" description:"Dialing timeout. (0 means wait indefinitely)" default:"5m"`
 
 	Database string `long:"database" description:"The name of the database to use." default:"atc"`
@@ -63,6 +65,10 @@ func (config PostgresConfig) ConnectionString() string {
 
 	if config.ConnectTimeout != 0 {
 		properties["connect_timeout"] = strconv.Itoa(int(config.ConnectTimeout.Seconds()))
+	}
+
+	if config.BinaryParameters {
+		properties["binary_parameters"] = "yes"
 	}
 
 	var pairs []string

--- a/postgres_config_test.go
+++ b/postgres_config_test.go
@@ -24,3 +24,21 @@ var _ = Describe("PostgresConfig", func() {
 		})
 	})
 })
+
+var _ = Describe("PostgresConfig", func() {
+	Describe("ConnectionString", func() {
+		It("adds binary_parameters correctly", func() {
+			Expect(flag.PostgresConfig{
+				Host: "1.2.3.4",
+				Port: 5432,
+
+				User:     "some user",
+				Password: "not-so-important",
+
+				BinaryParameters: true,
+
+				Database: "atc",
+			}.ConnectionString()).To(Equal("binary_parameters='yes' dbname='atc' host='1.2.3.4' password='not-so-important' port=5432 sslmode='' user='some user'"))
+		})
+	})
+})


### PR DESCRIPTION
This commit adds support for the DSN parameter binary_parameters.

This is related to https://github.com/concourse/concourse/discussions/6936