### PR TITLE
Remove the BinaryParameters flag from Postgres

### DIFF
--- a/postgres_config.go
+++ b/postgres_config.go
@@ -23,8 +23,6 @@ type PostgresConfig struct {
 	ClientCert File   `long:"client-cert" description:"Client cert file location."`
 	ClientKey  File   `long:"client-key"  description:"Client key file location."`
 
-	BinaryParameters bool `long:"binary-parameters" description:"Whether or not to use binary parameters for prepared statements."`
-
 	ConnectTimeout time.Duration `long:"connect-timeout" description:"Dialing timeout. (0 means wait indefinitely)" default:"5m"`
 
 	Database string `long:"database" description:"The name of the database to use." default:"atc"`
@@ -65,10 +63,6 @@ func (config PostgresConfig) ConnectionString() string {
 
 	if config.ConnectTimeout != 0 {
 		properties["connect_timeout"] = strconv.Itoa(int(config.ConnectTimeout.Seconds()))
-	}
-
-	if config.BinaryParameters {
-		properties["binary_parameters"] = "yes"
 	}
 
 	var pairs []string

--- a/postgres_config_test.go
+++ b/postgres_config_test.go
@@ -24,21 +24,3 @@ var _ = Describe("PostgresConfig", func() {
 		})
 	})
 })
-
-var _ = Describe("PostgresConfig", func() {
-	Describe("ConnectionString", func() {
-		It("adds binary_parameters correctly", func() {
-			Expect(flag.PostgresConfig{
-				Host: "1.2.3.4",
-				Port: 5432,
-
-				User:     "some user",
-				Password: "not-so-important",
-
-				BinaryParameters: true,
-
-				Database: "atc",
-			}.ConnectionString()).To(Equal("binary_parameters='yes' dbname='atc' host='1.2.3.4' password='not-so-important' port=5432 sslmode='' user='some user'"))
-		})
-	})
-})


### PR DESCRIPTION
We've changed the driver we're using upstream from lib/pq to Pgx.

https://github.com/concourse/concourse/pull/9066

It seems this setting was only needed for folks using PgBouncer and was based on info from a 2019 blog post:

- https://github.com/concourse/concourse/discussions/6936
    - https://blog.bullgare.com/2019/06/pgbouncer-and-prepared-statements/

For PgBouncer to work with pgx it was previously suggested that one change the Pgx ExecMode to the SimpleProtocol. Recent pgx user reports indicate that >1.21.0 of PgBouncer should work without any config changes though: https://github.com/jackc/pgx/discussions/1784

The most recent 1.24.0 PgBouncer release also indicates that Prepared statements are now supported: https://www.pgbouncer.org/2025/01/pgbouncer-1.24.0

Therefore I don't think we need to change any configuration at the sql driver level now. We definitely don't need the BinaryParameters flag anymore since it was specific to lib/pq and doesn't work at all with pgx. Trying to set this flag with pgx results in an error.